### PR TITLE
Full-screen Live layout demo for SlashInput example

### DIFF
--- a/examples/test_slash_input.rb
+++ b/examples/test_slash_input.rb
@@ -6,45 +6,61 @@ items = [
   { label: 'Help', value: '/help', description: 'Show available commands' },
   { label: 'Status', value: '/status', description: 'Print current status' },
   { label: 'Deploy', value: '/deploy', description: 'Run deployment flow' },
-  { label: 'Test', value: '/test', description: 'Execute test suite' }
+  { label: 'Test', value: '/test', description: 'Execute test suite' },
+  { label: 'Quit', value: '/quit', description: 'Exit this demo' }
 ]
 
-selected_item = nil
-submitted_value = nil
+status_lines = [
+  'SlashInput + Layout + Live 全屏示例',
+  "输入 '/' 召唤菜单，↑/↓ 选择，Enter 选中命令，Esc 关闭菜单。",
+  "输入 /quit 后按 Enter 退出。"
+]
+
+layout = RubyRich::Layout.new(name: :root)
+layout.split_column(
+  RubyRich::Layout.new(name: :header, size: 5),
+  RubyRich::Layout.new(name: :body, ratio: 1),
+  RubyRich::Layout.new(name: :input, size: 10)
+)
 
 slash_input = RubyRich::SlashInput.new(
   prompt: 'Command> ',
   items: items,
-  width: 80,
   on_select: lambda { |item, _live|
-    selected_item = item
+    status_lines << "Selected: #{item[:label]} (#{item[:value]})"
   },
-  on_submit: lambda { |value, _live|
-    submitted_value = value
+  on_submit: lambda { |value, live|
+    status_lines << "Submitted: #{value}"
+    live.stop if value.strip == '/quit'
   }
 )
 
-puts 'Testing SlashInput:'
-puts '=' * 50
+slash_input.attach(layout)
 
-# Type "/st" to filter to Status
-slash_input.handle_key(name: :string, value: '/')
-slash_input.handle_key(name: :string, value: 's')
-slash_input.handle_key(name: :string, value: 't')
+layout[:header].content = RubyRich::Panel.new(
+  'RubyRich SlashInput Demo',
+  title: 'Header'
+)
 
-puts "\nAfter typing '/st':"
-puts slash_input.render
+layout[:body].content = Object.new.tap do |view|
+  view.define_singleton_method(:render) do
+    visible_lines = status_lines.last(20)
+    panel = RubyRich::Panel.new(visible_lines.join("\n"), title: 'Event Log / Tips')
+    panel.height = layout[:body].height
+    panel.width = layout[:body].width
+    panel.render
+  end
+end
 
-# Select the first match with Enter
-slash_input.handle_key(name: :enter)
+layout[:input].content = Object.new.tap do |view|
+  view.define_singleton_method(:render) do
+    panel = RubyRich::Panel.new(slash_input.render.join("\n"), title: 'Input')
+    panel.height = layout[:input].height
+    panel.width = layout[:input].width
+    panel.render
+  end
+end
 
-puts "\nAfter pressing Enter to select a command:"
-puts slash_input.render
-puts "Selected item: #{selected_item&.dig(:label) || '(none)'}"
-puts "Current value: #{slash_input.value.inspect}"
-
-# Submit selected command
-slash_input.handle_key(name: :enter)
-puts "Submitted value: #{submitted_value.inspect}"
-
-puts "\nSlashInput test completed!"
+RubyRich::Live.start(layout, refresh_rate: 24) do |live|
+  live.listening = true
+end


### PR DESCRIPTION
### Motivation
- Provide a full-screen TUI example that shows how to compose `RubyRich::Layout` with `RubyRich::SlashInput` and run it using `RubyRich::Live.start`, so users can see menu invocation, selection and submission flows in a realistic app layout.

### Description
- Rewrote `examples/test_slash_input.rb` into a three-pane full-screen layout (header, body, input) using `RubyRich::Layout` and `split_column`.
- Integrated `RubyRich::SlashInput` into the bottom input panel and called `slash_input.attach(layout)` so the root layout receives key events for `/`, arrow keys, `Enter` and `Esc` handling.
- Implemented a body panel that renders an event log of selections/submissions, and added an `on_select` and `on_submit` callback that append events into the log and stop the `Live` loop when `/quit` is submitted.
- Starts the demo with `RubyRich::Live.start(layout, refresh_rate: 24)` and enables keyboard listening via `live.listening = true`.

### Testing
- Ran a syntax check with `ruby -c examples/test_slash_input.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9865f6e848332aa5c80288c7e5897)